### PR TITLE
Fix compiler errors

### DIFF
--- a/mkgpt.c
+++ b/mkgpt.c
@@ -469,7 +469,7 @@ int check_parts()
 	}
 	else if(image_sects < needed_file_length)
 	{
-		fprintf(stderr, "requested image size (%lu) is too small to hold the partitions\n", image_sects * sect_size);
+		fprintf(stderr, "requested image size (%llu) is too small to hold the partitions\n", image_sects * sect_size);
 		return -1;
 	}
 
@@ -496,7 +496,7 @@ void write_output()
 	mbr[446 + 7] = 0xff;						/* EndingCHS = 0xffffff */
 	*(uint32_t *)&mbr[446 + 8] = 0x1;			/* StartingLBA = 1 */
 		
-	if(image_sects > 0xffffffff)
+	if(image_sects > (long int)0xffffffff)
 		*(uint32_t *)&mbr[446 + 12] = 0xffffffff;
 	else
 		*(uint32_t *)&mbr[446 + 12] = (uint32_t)image_sects - 1;


### PR DESCRIPTION
Fixes compiler errors as shown.

`
mkgpt.c: In function 'check_parts':
mkgpt.c:472:58: error: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Werror=format=]
  472 |                 fprintf(stderr, "requested image size (%lu) is too small to hold the partitions\n", image_sects * sect_size);
      |                                                        ~~^                                          ~~~~~~~~~~~~~~~~~~~~~~~
      |                                                          |                                                      |
      |                                                          long unsigned int                                      size_t {aka long long unsigned int}
      |                                                        %llu
mkgpt.c: In function 'write_output':
mkgpt.c:499:24: error: comparison of integer expressions of different signedness: 'long int' and 'unsigned int' [-Werror=sign-compare]
  499 |         if(image_sects > 0xffffffff)
      |                        ^
cc1.exe: all warnings being treated as errors
make: *** [Makefile:375: mkgpt.o] Error 1

`
Compiler: gcc.exe (Rev7, Built by MSYS2 project) 13.1.0

